### PR TITLE
58 hero section

### DIFF
--- a/src/app/_components/hero/Hero.module.scss
+++ b/src/app/_components/hero/Hero.module.scss
@@ -1,19 +1,57 @@
 @import "../../../styles/mantine";
 
-.hero {
-  background: yellow;
-  @media (max-width: $mantine-breakpoint-md) {
-    background: green;
+.container {
+  height: 90vh;
+  position: relative;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.heroImage {
+  position: absolute;
+  width: 100%; 
+  height: 100%; 
+  object-fit: cover; 
+}
+
+.overlay {
+  background-color: rgba(0, 0, 0, 0.333);
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  right: 0;
+  left: 0;
+  z-index: 1;
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  width: 100%;
+  gap: 16px;
+  align-self: stretch;
+  position: relative;
+  z-index: 5; 
+  max-width: 1120px;
+
+  @media (max-width: $mantine-breakpoint-lg) {
+    padding: 0 32px;
+  }
+  @media (max-width: $mantine-breakpoint-xs) {
+    padding: 0 16px;
+
   }
 }
 
 .title {
-  color: red;
+  color: var(--mantine-color-white-3);
+  max-width: 600px;
+
 }
 
-.hero {
-  @media (max-width: $mantine-breakpoint-xs) {
-    background-color: red;
-  }
+.buttonContainer {
+  display: flex;
+  gap: 40px;
 }
-

--- a/src/app/_components/hero/Hero.module.scss
+++ b/src/app/_components/hero/Hero.module.scss
@@ -1,3 +1,5 @@
+@import "../../../styles/mantine";
+
 .hero {
   background: yellow;
   @media (max-width: $mantine-breakpoint-md) {
@@ -14,3 +16,4 @@
     background-color: red;
   }
 }
+

--- a/src/app/_components/hero/Hero.tsx
+++ b/src/app/_components/hero/Hero.tsx
@@ -1,4 +1,4 @@
-import { Container, Title } from '@mantine/core';
+import { Box, Title } from '@mantine/core';
 import Link from 'next/link';
 import { type IHero } from '../../interfaces';
 import ShortButton from '../shortButton/ShortButton';
@@ -6,20 +6,33 @@ import classes from './Hero.module.scss';
 
 export default async function Hero({ hero }: { hero: IHero }) {
   return (
-    <Container className={classes.hero}>
-      <Title order={1} className={classes.title}>
-        {hero.title}
-      </Title>
+    <Box className={classes.container}>
       {hero.description && <p>{hero.description}</p>}
-      {hero.image && <img src={hero.image.url} alt={hero.image.alt}></img>}
-      {hero.buttons &&
-        hero.buttons.map((button, i) => <button key={i}>{button.text}</button>)}
-      <Link href='/menu'>
-        <ShortButton text={'Meny'} color={'orange'} />
-      </Link>
-      <Link href='/booking'>
-        <ShortButton text={'Boka bord'} color={'black'} />
-      </Link>
-    </Container>
+      <Box className={classes.overlay} />
+      {hero.image && (
+        <img
+          className={classes.heroImage}
+          src={hero.image.url}
+          alt={hero.image.alt}
+        />
+      )}
+      <Box className={classes.content}>
+        {hero.buttons &&
+          hero.buttons.map((button, i) => (
+            <button key={i}>{button.text}</button>
+          ))}
+        <Title order={1} className={classes.title}>
+          {hero.title}
+        </Title>
+        <Box className={classes.buttonContainer}>
+          <Link href='/menu'>
+            <ShortButton text={'Meny'} color={'orange'} />
+          </Link>
+          <Link href='/booking'>
+            <ShortButton text={'Boka bord'} color={'black'} />
+          </Link>
+        </Box>
+      </Box>
+    </Box>
   );
 }

--- a/src/app/_components/hero/Hero.tsx
+++ b/src/app/_components/hero/Hero.tsx
@@ -1,12 +1,10 @@
-/* eslint-disable @typescript-eslint/prefer-optional-chain */
-
 import { Container, Title } from '@mantine/core';
-import { IHero } from '../../interfaces';
-import classes from './Hero.module.css';
+import Link from 'next/link';
+import { type IHero } from '../../interfaces';
+import ShortButton from '../shortButton/ShortButton';
+import classes from './Hero.module.scss';
 
 export default async function Hero({ hero }: { hero: IHero }) {
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-
   return (
     <Container className={classes.hero}>
       <Title order={1} className={classes.title}>
@@ -16,6 +14,12 @@ export default async function Hero({ hero }: { hero: IHero }) {
       {hero.image && <img src={hero.image.url} alt={hero.image.alt}></img>}
       {hero.buttons &&
         hero.buttons.map((button, i) => <button key={i}>{button.text}</button>)}
+      <Link href='/menu'>
+        <ShortButton text={'Meny'} color={'orange'} />
+      </Link>
+      <Link href='/booking'>
+        <ShortButton text={'Boka bord'} color={'black'} />
+      </Link>
     </Container>
   );
 }

--- a/src/app/_components/selectedDishes/SelectedDishes.module.scss
+++ b/src/app/_components/selectedDishes/SelectedDishes.module.scss
@@ -31,11 +31,5 @@
     h5 {
       margin-bottom: 8px;
     }
-
-    a {
-      background-color: var(--mantine-color-orange-3);
-      border-radius: var(--mantine-radius-secondary);
-      padding: 8px 16px;
-    }
   }
 }

--- a/src/app/_components/selectedDishes/SelectedDishes.module.scss
+++ b/src/app/_components/selectedDishes/SelectedDishes.module.scss
@@ -1,7 +1,7 @@
 @import '../../../styles/mantine';
 
 .container {
-  padding-top: 48px;
+  padding: 48px 0 0;
 
   h2 {
     grid-column: 1 / -1;
@@ -10,7 +10,7 @@
 
   .grid {
     display: grid;
-    margin: 32px 44px;
+    margin: 0 40px;
     grid-template-columns: repeat(3, 328px);
     gap: 32px 24px;
     justify-content: center;

--- a/src/app/_components/selectedDishes/SelectedDishes.tsx
+++ b/src/app/_components/selectedDishes/SelectedDishes.tsx
@@ -4,6 +4,7 @@ import { Box, Container, Title } from '@mantine/core';
 import Link from 'next/link';
 import type { IDish } from '../../interfaces';
 import DishCard from '../dishCard/DishCard';
+import ShortButton from '../shortButton/ShortButton';
 import scss from './SelectedDishes.module.scss';
 
 export default function SelectedDishes({ dishes }: { dishes: IDish[] }) {
@@ -16,7 +17,9 @@ export default function SelectedDishes({ dishes }: { dishes: IDish[] }) {
         ))}
         <Box className={scss.bottom}>
           <Title order={5}>Ta del av hela vårt utbud</Title>
-          <Link href='/menu'>Meny</Link>
+          <Link href='/menu'>
+            <ShortButton text={'Meny'} color={'orange'} />
+          </Link>
         </Box>
       </Box>
     </Container>

--- a/src/app/_components/shortButton/ShortButton.module.scss
+++ b/src/app/_components/shortButton/ShortButton.module.scss
@@ -13,10 +13,6 @@
     color: var(--button-text-color);
   }
   
-  .container:hover {
-    background: var(--mantine-color-white-9);
-  }
-  
   .container:active {
     transform: translateY(1px);
     box-shadow: var(--mantine-shadow-secondary);
@@ -29,8 +25,16 @@
     --button-border: 1px solid var(--mantine-color-orange-3);
     border: var(--button-border);
   }
+
+  .black:hover {
+    background: var(--mantine-color-white-9);
+  }
   
   .orange {
     --button-background: var(--mantine-color-orange-3);
     --button-text-color: var(--mantine-color-black-3);
+  }
+
+  .orange:hover {
+    background: var(--mantine-color-orange-1); 
   }

--- a/src/app/_components/shortButton/ShortButton.module.scss
+++ b/src/app/_components/shortButton/ShortButton.module.scss
@@ -1,0 +1,36 @@
+@import "../../../styles/mantine";
+
+.container {
+    display: flex;
+    padding: 8px 16px;
+    justify-content: center;
+    align-items: center;
+    gap: 8px;
+    align-self: stretch;
+    border-radius: var(--mantine-radius-secondary);
+    cursor: pointer;
+    background: var(--button-background);
+    color: var(--button-text-color);
+  }
+  
+  .container:hover {
+    background: var(--mantine-color-white-9);
+  }
+  
+  .container:active {
+    transform: translateY(1px);
+    box-shadow: var(--mantine-shadow-secondary);
+    background: var(--mantine-color-white-8);
+  }
+  
+  .black {
+    --button-background: var(--mantine-color-black-3);
+    --button-text-color: var(--mantine-color-orange-3);
+    --button-border: 1px solid var(--mantine-color-orange-3);
+    border: var(--button-border);
+  }
+  
+  .orange {
+    --button-background: var(--mantine-color-orange-3);
+    --button-text-color: var(--mantine-color-black-3);
+  }

--- a/src/app/_components/shortButton/ShortButton.tsx
+++ b/src/app/_components/shortButton/ShortButton.tsx
@@ -1,0 +1,26 @@
+import { Title } from '@mantine/core';
+
+import classes from './ShortButton.module.scss';
+
+interface IShortButton {
+  text: string;
+  color: 'black' | 'orange';
+  type?: 'button' | 'submit';
+  onClick?: () => void;
+}
+
+export default function ShortButton({
+  text: text,
+  color,
+  type = 'button',
+  onClick,
+}: IShortButton) {
+  // Assign a CSS class to 'buttonColor' based on the 'color' prop passed from the parent.
+  // The 'color' prop should be either 'black' or 'orange'.
+  const buttonColor = `${classes.container} ${classes[color]}`;
+  return (
+    <button className={buttonColor} type={type} onClick={onClick}>
+      <Title order={6}>{text}</Title>
+    </button>
+  );
+}


### PR DESCRIPTION
## Problem

Sidan hade en uppmockad Hero-sektionen, som inte följde designen.

## Lösning / Implementation

Hero-sektionen är nu skapad efter designen i Figma med tillagda länkar från knapparna. 

## Testning

Hero-sektionen fyller nu funktionen av att göra användarens första intryck lite trevligare med ett fokus på hemsidans meny och boka bord-del.

![Screenshot 2024-01-15 at 17 24 28](https://github.com/Examensarbete-Sebbe-Ellen-o-Linus/DinePal/assets/115704961/54532547-d2b0-40d7-b5e5-a95a719d2e40)

![Screenshot 2024-01-15 at 17 25 15](https://github.com/Examensarbete-Sebbe-Ellen-o-Linus/DinePal/assets/115704961/4a2667a9-dd49-4f5c-be5b-a8d7857ca70e)

![Screenshot 2024-01-15 at 17 25 27](https://github.com/Examensarbete-Sebbe-Ellen-o-Linus/DinePal/assets/115704961/1d0d9518-4720-4705-a848-e5d65beb6f1e)
