### PR TITLE
56 create gallery

### DIFF
--- a/src/app/gallery/page.module.scss
+++ b/src/app/gallery/page.module.scss
@@ -1,7 +1,7 @@
 @import '../../styles/mantine';
 
 .container {
-  padding: 48px 0;
+  padding: 48px 32px;
 
   h2 {
     margin-bottom: 16px;
@@ -20,29 +20,25 @@
     }
 
     @media (max-width: $mantine-breakpoint-md) {
-      grid-template-columns: repeat(6, 1fr);
-
-      > div {
-        grid-area: span 1 / span 3 !important;
-      }
-
-      > div:nth-child(3n) {
-        grid-area: span 2 / span 6 !important;
-      }
-    }
-
-    @media (max-width: $mantine-breakpoint-sm) {
       grid-template-columns: repeat(2, 1fr);
 
       > div {
-        grid-area: span 2 / span 6 !important;
+        grid-area: span 1 / span 1 !important;
+      }
+
+      > div:nth-child(3n) {
+        grid-area: span 1 / span 2 !important;
+      }
+    }
+
+    @media (max-width: $mantine-breakpoint-xs) {
+      > div {
+        grid-area: span 1 / span 2 !important;
       }
     }
   }
 
-  grid-auto-rows: 165px;
-
-  @media (max-width: $mantine-breakpoint-sm) {
+  @media (max-width: $mantine-breakpoint-md) {
     padding: 0 32px 48px;
   }
 }

--- a/src/app/gallery/page.module.scss
+++ b/src/app/gallery/page.module.scss
@@ -1,3 +1,5 @@
+@import '../../styles/mantine';
+
 .container {
   padding: 48px 0;
 
@@ -9,12 +11,38 @@
     display: grid;
     gap: 16px;
     grid-template-columns: repeat(12, 1fr);
-    grid-template-rows: repeat(auto-fill, 325px);
+    grid-auto-rows: 325px;
 
     img {
       width: 100%;
       height: 100%;
       object-fit: cover;
     }
+
+    @media (max-width: $mantine-breakpoint-md) {
+      grid-template-columns: repeat(6, 1fr);
+
+      > div {
+        grid-area: span 1 / span 3 !important;
+      }
+
+      > div:nth-child(3n) {
+        grid-area: span 2 / span 6 !important;
+      }
+    }
+
+    @media (max-width: $mantine-breakpoint-sm) {
+      grid-template-columns: repeat(2, 1fr);
+
+      > div {
+        grid-area: span 2 / span 6 !important;
+      }
+    }
+  }
+
+  grid-auto-rows: 165px;
+
+  @media (max-width: $mantine-breakpoint-sm) {
+    padding: 0 32px 48px;
   }
 }

--- a/src/app/gallery/page.module.scss
+++ b/src/app/gallery/page.module.scss
@@ -17,6 +17,7 @@
       width: 100%;
       height: 100%;
       object-fit: cover;
+      border-radius: var(--mantine-radius-primary);
     }
 
     @media (max-width: $mantine-breakpoint-md) {

--- a/src/app/gallery/page.module.scss
+++ b/src/app/gallery/page.module.scss
@@ -1,0 +1,20 @@
+.container {
+  padding: 48px 0;
+
+  h2 {
+    margin-bottom: 16px;
+  }
+
+  .grid {
+    display: grid;
+    gap: 16px;
+    grid-template-columns: repeat(12, 1fr);
+    grid-template-rows: repeat(auto-fill, 325px);
+
+    img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+    }
+  }
+}

--- a/src/app/gallery/page.tsx
+++ b/src/app/gallery/page.tsx
@@ -1,24 +1,43 @@
-import { Title } from '@mantine/core';
+import { Container, Title } from '@mantine/core';
 import { fetchGalleryPageData } from '../../server/sanity/sanity.utils';
+import scss from './page.module.scss';
 
 export default async function GalleryPage() {
   const galleryPageData = await fetchGalleryPageData();
 
-  // Render loading state if data is not yet fetched
+  const gridPattern = [
+    { col: 3, row: 1 },
+    { col: 3, row: 1 },
+    { col: 6, row: 1 },
+    { col: 4, row: 2 },
+    { col: 4, row: 1 },
+    { col: 4, row: 2 },
+    { col: 4, row: 1 },
+  ];
+
   if (!galleryPageData) {
     return <div>Loading...</div>;
   }
   const { galleryImgs, title } = galleryPageData;
 
   return (
-    <>
-      <Title order={2}>Gallery</Title>
-      <div>{title}</div>
-      <div>
-        {galleryImgs?.map((image, i) => (
-          <img key={i} src={image.url} alt={image.alt} />
-        ))}
+    <Container size={1120} className={scss.container}>
+      <Title order={2}>{title}</Title>
+      <div className={scss.grid}>
+        {galleryImgs?.map((image, index) => {
+          const pattern = gridPattern[index % gridPattern.length];
+          if (!pattern) return null;
+          const style = {
+            gridColumn: `span ${pattern.col}`,
+            gridRow: `span ${pattern.row}`,
+          };
+          return (
+            <div key={index} className={scss.col} style={style}>
+              <img src={image.url} alt={image.alt} className={scss.image} />
+            </div>
+          );
+        })}
       </div>
-    </>
+    </Container>
   );
 }

--- a/src/app/gallery/page.tsx
+++ b/src/app/gallery/page.tsx
@@ -21,7 +21,7 @@ export default async function GalleryPage() {
   const { galleryImgs, title } = galleryPageData;
 
   return (
-    <Container size={1120} className={scss.container}>
+    <Container size={1120} className={scss.container} fluid>
       <Title order={2}>{title}</Title>
       <div className={scss.grid}>
         {galleryImgs?.map((image, index) => {

--- a/src/app/gallery/page.tsx
+++ b/src/app/gallery/page.tsx
@@ -21,7 +21,7 @@ export default async function GalleryPage() {
   const { galleryImgs, title } = galleryPageData;
 
   return (
-    <Container size={1120} className={scss.container} fluid>
+    <Container size={1120} className={scss.container}>
       <Title order={2}>{title}</Title>
       <div className={scss.grid}>
         {galleryImgs?.map((image, index) => {

--- a/src/app/theme/AccentColor.tsx
+++ b/src/app/theme/AccentColor.tsx
@@ -10,7 +10,6 @@ export default function AccentColor() {
       const color = await fetchAccentColor();
       if (color) {
         const colorShades = generateColorShades(color.value);
-        console.log(colorShades);
         colorShades.forEach((shade, index) => {
           document.documentElement.style.setProperty(
             `--mantine-color-orange-${index}`,

--- a/src/server/sanity/sanity.utils.ts
+++ b/src/server/sanity/sanity.utils.ts
@@ -85,7 +85,8 @@ export const fetchGalleryPageData = async (): Promise<IGalleryPage> => {
   title,
   "galleryImgs": galleryImgs[]{
     "alt": coalesce(alt, "No alt text"),
-    "url": asset->url
+    "url": asset->url,
+    "key": _key
   }  
   `
   return fetchDocumentById('galleryPage', additionalSelections)

--- a/src/server/sanity/schemas/pages/galleryPage.ts
+++ b/src/server/sanity/schemas/pages/galleryPage.ts
@@ -31,7 +31,6 @@ export default defineType({
     {
       name: 'galleryImgs',
       title: 'Gallery Images',
-      description: 'hi there',
       group: 'gallery',
       type: 'array',
       of: [


### PR DESCRIPTION
## Problem

Sidan hade inte innehåll och styling för galleri-sidan.

## Lösning / Implementation

Nu visas bilderna i ett responsivt grid. De sju första bilderna är satta i ett mönster/grid som sedan upprepas om man lägger till fler bilder. Tillfälliga bilder är upplagda på sanity för att fylla ut griden.

## Testning

Galleriet ska visa samtliga bilder från galleryPage på sanity.

<img width="569" alt="Skärmavbild 2024-01-16 kl  10 07 36" src="https://github.com/Examensarbete-Sebbe-Ellen-o-Linus/DinePal/assets/80984009/8ad1b671-67d4-44a6-9ac9-53ec9c8c386b">
