### PR TITLE
97 fix head for all pages

### DIFF
--- a/src/app/_components/bookingForm/BookingForm.tsx
+++ b/src/app/_components/bookingForm/BookingForm.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 'use client';
 import { Box, NumberInput, Select, TextInput, Textarea } from '@mantine/core';
 import { DatePicker, type DatePickerProps } from '@mantine/dates';
@@ -80,13 +81,28 @@ export default function BookingForm() {
   // This is just to be able to change the color of the selected day in the calendar
   const getDayProps: DatePickerProps['getDayProps'] = date => {
     const selectedDate = formik.values.date;
+    const specialDates = ['2024-01-10', '2024-01-8', '2024-01-6'];
+    const styles: any = {};
     if (selectedDate && dayjs(date).isSame(selectedDate, 'day')) {
-      return {
-        style: {
-          // The theme is acting strange. I've to set up an alternate color to prevent
-          backgroundColor: theme.colors?.black?.[3] ?? '#221F1F',
-        },
-      };
+      styles.backgroundColor = theme.colors?.black?.[3] ?? '#221F1F';
+    }
+
+    if (date.getDate() === 29 && date.getMonth() === 0) {
+      styles.backgroundColor = theme.colors?.red?.[6] ?? '#FA5252';
+      styles.color = theme.colors?.white?.[1] ?? '#ffffff';
+      styles.borderRadius = '50%';
+    }
+
+    if (
+      specialDates.some(specialDate => dayjs(date).isSame(specialDate, 'day'))
+    ) {
+      styles.backgroundColor = theme.colors?.red?.[6] ?? '#FA5252';
+      styles.color = theme.colors?.white?.[1] ?? '#ffffff';
+      styles.borderRadius = '50%';
+    }
+
+    if (Object.keys(styles).length > 0) {
+      return { style: styles };
     }
     return {};
   };
@@ -193,6 +209,7 @@ export default function BookingForm() {
             const guestsNumber = +formik.values.guests;
             if (guestsNumber >= 1 && guestsNumber <= 8) {
               void formik.setFieldValue('date', date);
+              console.log(date);
             }
           }}
         />

--- a/src/app/_components/orderCard/OrderCard.tsx
+++ b/src/app/_components/orderCard/OrderCard.tsx
@@ -11,6 +11,7 @@ import {
 } from '@mantine/core';
 import type { Order, Orderstatus } from '@prisma/client';
 import TimeAgo from 'javascript-time-ago';
+import en from 'javascript-time-ago/locale/en.json';
 import sv from 'javascript-time-ago/locale/sv.json';
 import ReactTimeAgo from 'react-time-ago';
 import { api } from '~/trpc/react';
@@ -21,8 +22,10 @@ type Props = {
   order: Order;
 };
 
+TimeAgo.addDefaultLocale(sv);
+TimeAgo.addLocale(en);
+
 export default function OrderCard({ order }: Props) {
-  TimeAgo.addDefaultLocale(sv);
   const quantity = order.cart.dish.reduce((acc, dish) => {
     return acc + dish.quantity;
   }, 0);
@@ -154,7 +157,7 @@ export default function OrderCard({ order }: Props) {
           <Box>
             {order && order.orderStatus !== 'completed' && (
               <Text className={classes.timeAgo}>
-                Tillagd <ReactTimeAgo date={order.createdAt!} />
+                Tillagd <ReactTimeAgo locale='sv' date={order.createdAt!} />
               </Text>
             )}
             <Text>

--- a/src/app/booking/page.tsx
+++ b/src/app/booking/page.tsx
@@ -1,23 +1,10 @@
-import type { Metadata, ResolvingMetadata } from 'next';
+import type { Metadata } from 'next';
 import { fetchBookingPageData } from '../../server/sanity/sanity.utils';
 import BookingContent from '../_components/bookingContent/BookingContent';
 
-export async function generateMetadata(
-  parent: ResolvingMetadata
-): Promise<Metadata> {
-  try {
-    const bookingPageData = await fetchBookingPageData();
-    return {
-      title: 'Dinepal - ' + bookingPageData.seo.metaTitle,
-      description: bookingPageData.seo.metaDescription,
-    };
-  } catch (error) {
-    console.log(error);
-    return {
-      title: 'Dinepal',
-    };
-  }
-}
+export const metadata: Metadata = {
+  title: 'Dinepal - Booking',
+};
 
 export default async function Booking() {
   const data = await fetchBookingPageData();

--- a/src/app/booking/page.tsx
+++ b/src/app/booking/page.tsx
@@ -3,7 +3,7 @@ import { fetchBookingPageData } from '../../server/sanity/sanity.utils';
 import BookingContent from '../_components/bookingContent/BookingContent';
 
 export const metadata: Metadata = {
-  title: 'Dinepal - Booking',
+  title: 'Dinepal - Bordsbokning',
 };
 
 export default async function Booking() {

--- a/src/app/booking/page.tsx
+++ b/src/app/booking/page.tsx
@@ -1,5 +1,23 @@
+import type { Metadata, ResolvingMetadata } from 'next';
 import { fetchBookingPageData } from '../../server/sanity/sanity.utils';
 import BookingContent from '../_components/bookingContent/BookingContent';
+
+export async function generateMetadata(
+  parent: ResolvingMetadata
+): Promise<Metadata> {
+  try {
+    const bookingPageData = await fetchBookingPageData();
+    return {
+      title: 'Dinepal - ' + bookingPageData.seo.metaTitle,
+      description: bookingPageData.seo.metaDescription,
+    };
+  } catch (error) {
+    console.log(error);
+    return {
+      title: 'Dinepal',
+    };
+  }
+}
 
 export default async function Booking() {
   const data = await fetchBookingPageData();

--- a/src/app/business/page.tsx
+++ b/src/app/business/page.tsx
@@ -8,7 +8,6 @@ import classes from './businessPage.module.scss';
 
 export const metadata: Metadata = {
   title: 'Dinepal - Business',
-  description: 'Dinepal - Business',
 };
 
 export default async function BusinessPage() {

--- a/src/app/business/page.tsx
+++ b/src/app/business/page.tsx
@@ -1,9 +1,15 @@
 import { Box, Button, Text } from '@mantine/core';
 import { PrismaClient } from '@prisma/client';
+import { Metadata } from 'next';
 import Link from 'next/link';
 import { getServerAuthSession } from '~/server/auth';
 import Orders from '../_components/orders/Orders';
 import classes from './businessPage.module.scss';
+
+export const metadata: Metadata = {
+  title: 'Dinepal - Business',
+  description: 'Dinepal - Business',
+};
 
 export default async function BusinessPage() {
   const prisma = new PrismaClient();

--- a/src/app/business/page.tsx
+++ b/src/app/business/page.tsx
@@ -1,6 +1,6 @@
 import { Box, Button, Text } from '@mantine/core';
 import { PrismaClient } from '@prisma/client';
-import { Metadata } from 'next';
+import type { Metadata } from 'next';
 import Link from 'next/link';
 import { getServerAuthSession } from '~/server/auth';
 import Orders from '../_components/orders/Orders';

--- a/src/app/checkout/page.tsx
+++ b/src/app/checkout/page.tsx
@@ -1,9 +1,27 @@
 import { Box, Container, Text, Title } from '@mantine/core';
 
+import type { Metadata, ResolvingMetadata } from 'next';
 import { fetchCheckoutPageData } from '~/server/sanity/sanity.utils';
 import CheckoutForm from '../_components/checkoutForm/CheckoutForm';
 import CheckoutSummary from '../_components/checkoutSummary/CheckoutSummary';
 import classes from './page.module.scss';
+
+export async function generateMetadata(
+  parent: ResolvingMetadata
+): Promise<Metadata> {
+  try {
+    const checkoutPageData = await fetchCheckoutPageData();
+    return {
+      title: 'Dinepal - ' + checkoutPageData.seo.metaTitle,
+      description: checkoutPageData.seo.metaDescription,
+    };
+  } catch (error) {
+    console.log(error);
+    return {
+      title: 'Dinepal',
+    };
+  }
+}
 
 export default async function Checkout() {
   const checkoutPageData = await fetchCheckoutPageData();

--- a/src/app/checkout/page.tsx
+++ b/src/app/checkout/page.tsx
@@ -1,27 +1,14 @@
 import { Box, Container, Text, Title } from '@mantine/core';
 
-import type { Metadata, ResolvingMetadata } from 'next';
+import type { Metadata } from 'next';
 import { fetchCheckoutPageData } from '~/server/sanity/sanity.utils';
 import CheckoutForm from '../_components/checkoutForm/CheckoutForm';
 import CheckoutSummary from '../_components/checkoutSummary/CheckoutSummary';
 import classes from './page.module.scss';
 
-export async function generateMetadata(
-  parent: ResolvingMetadata
-): Promise<Metadata> {
-  try {
-    const checkoutPageData = await fetchCheckoutPageData();
-    return {
-      title: 'Dinepal - ' + checkoutPageData.seo.metaTitle,
-      description: checkoutPageData.seo.metaDescription,
-    };
-  } catch (error) {
-    console.log(error);
-    return {
-      title: 'Dinepal',
-    };
-  }
-}
+export const metadata: Metadata = {
+  title: 'Dinepal - Checkout',
+};
 
 export default async function Checkout() {
   const checkoutPageData = await fetchCheckoutPageData();

--- a/src/app/checkout/page.tsx
+++ b/src/app/checkout/page.tsx
@@ -7,7 +7,7 @@ import CheckoutSummary from '../_components/checkoutSummary/CheckoutSummary';
 import classes from './page.module.scss';
 
 export const metadata: Metadata = {
-  title: 'Dinepal - Checkout',
+  title: 'Dinepal - Kassa',
 };
 
 export default async function Checkout() {

--- a/src/app/gallery/page.tsx
+++ b/src/app/gallery/page.tsx
@@ -1,31 +1,11 @@
 import { Container, Title } from '@mantine/core';
-import type { Metadata, ResolvingMetadata } from 'next';
+import type { Metadata } from 'next';
 import { fetchGalleryPageData } from '../../server/sanity/sanity.utils';
 import scss from './page.module.scss';
 
-// export const metadata: Metadata = {
-//   title: 'Dinepal - Galleri',
-// };
-
-export async function generateMetadata(
-  parent: ResolvingMetadata
-): Promise<Metadata> {
-  try {
-    const galleryPageData = await fetchGalleryPageData();
-    console.log('in the metadata', galleryPageData);
-    return {
-      title: 'Dinepal - ' + galleryPageData.seo.metaTitle,
-      description: galleryPageData.seo.metaDescription,
-    };
-  } catch (error) {
-    console.log(error);
-    return {
-      title: 'Dinepal',
-    };
-  }
-}
-
-// export default function Page({ params, searchParams }: Props) {}
+export const metadata: Metadata = {
+  title: 'Dinepal - Galleri',
+};
 
 export default async function GalleryPage() {
   const galleryPageData = await fetchGalleryPageData();

--- a/src/app/gallery/page.tsx
+++ b/src/app/gallery/page.tsx
@@ -9,7 +9,6 @@ export const metadata: Metadata = {
 
 export default async function GalleryPage() {
   const galleryPageData = await fetchGalleryPageData();
-  console.log(' in the component', galleryPageData);
 
   const gridPattern = [
     { col: 3, row: 1 },

--- a/src/app/gallery/page.tsx
+++ b/src/app/gallery/page.tsx
@@ -1,9 +1,35 @@
 import { Container, Title } from '@mantine/core';
+import type { Metadata, ResolvingMetadata } from 'next';
 import { fetchGalleryPageData } from '../../server/sanity/sanity.utils';
 import scss from './page.module.scss';
 
+// export const metadata: Metadata = {
+//   title: 'Dinepal - Galleri',
+// };
+
+export async function generateMetadata(
+  parent: ResolvingMetadata
+): Promise<Metadata> {
+  try {
+    const galleryPageData = await fetchGalleryPageData();
+    console.log('in the metadata', galleryPageData);
+    return {
+      title: 'Dinepal - ' + galleryPageData.seo.metaTitle,
+      description: galleryPageData.seo.metaDescription,
+    };
+  } catch (error) {
+    console.log(error);
+    return {
+      title: 'Dinepal',
+    };
+  }
+}
+
+// export default function Page({ params, searchParams }: Props) {}
+
 export default async function GalleryPage() {
   const galleryPageData = await fetchGalleryPageData();
+  console.log(' in the component', galleryPageData);
 
   const gridPattern = [
     { col: 3, row: 1 },

--- a/src/app/interfaces.ts
+++ b/src/app/interfaces.ts
@@ -87,6 +87,7 @@ export interface IBookingPage {
   _type: 'bookingPage';
   title: string;
   text: string;
+  seo: ISEO;
 }
 
 // Image section
@@ -150,6 +151,7 @@ export interface INews {
 export interface IMenuPage {
   title: string;
   promo: IPromo;
+  seo: ISEO;
 }
 export interface IPromo {
   text: string;

--- a/src/app/menu/page.tsx
+++ b/src/app/menu/page.tsx
@@ -1,24 +1,11 @@
-import type { Metadata, ResolvingMetadata } from 'next';
+import type { Metadata } from 'next';
 import { fetchDishes, fetchMenuPageData } from '~/server/sanity/sanity.utils';
 import MenuContent from '../_components/menuContent/MenuContent';
 import Promo from '../_components/promo/Promo';
 
-export async function generateMetadata(
-  parent: ResolvingMetadata
-): Promise<Metadata> {
-  try {
-    const menuPageData = await fetchMenuPageData();
-    return {
-      title: 'Dinepal - ' + menuPageData.seo.metaTitle,
-      description: menuPageData.seo.metaDescription,
-    };
-  } catch (error) {
-    console.log(error);
-    return {
-      title: 'Dinepal',
-    };
-  }
-}
+export const metadata: Metadata = {
+  title: 'Dinepal - Meny',
+};
 
 export default async function Menu() {
   const menu = await fetchMenuPageData();

--- a/src/app/menu/page.tsx
+++ b/src/app/menu/page.tsx
@@ -1,6 +1,24 @@
+import type { Metadata, ResolvingMetadata } from 'next';
 import { fetchDishes, fetchMenuPageData } from '~/server/sanity/sanity.utils';
 import MenuContent from '../_components/menuContent/MenuContent';
 import Promo from '../_components/promo/Promo';
+
+export async function generateMetadata(
+  parent: ResolvingMetadata
+): Promise<Metadata> {
+  try {
+    const menuPageData = await fetchMenuPageData();
+    return {
+      title: 'Dinepal - ' + menuPageData.seo.metaTitle,
+      description: menuPageData.seo.metaDescription,
+    };
+  } catch (error) {
+    console.log(error);
+    return {
+      title: 'Dinepal',
+    };
+  }
+}
 
 export default async function Menu() {
   const menu = await fetchMenuPageData();

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,11 +1,16 @@
 /* eslint-disable @next/next/no-img-element */
 import { Box } from '@mantine/core';
+import type { Metadata } from 'next';
 import { fetchHomePageData } from '~/server/sanity/sanity.utils';
 import About from './_components/about/About';
 import Hero from './_components/hero/Hero';
 import ImageSection from './_components/imageSection/ImageSection';
 import News from './_components/news/News';
 import SelectedDishes from './_components/selectedDishes/SelectedDishes';
+
+export const metadata: Metadata = {
+  title: 'Dinepal - Home',
+};
 
 export default async function Home() {
   const homePageData = await fetchHomePageData();

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,7 +9,7 @@ import News from './_components/news/News';
 import SelectedDishes from './_components/selectedDishes/SelectedDishes';
 
 export const metadata: Metadata = {
-  title: 'Dinepal - Home',
+  title: 'Dinepal - Hem',
 };
 
 export default async function Home() {

--- a/src/server/sanity/sanity.utils.ts
+++ b/src/server/sanity/sanity.utils.ts
@@ -109,6 +109,7 @@ export const fetchCheckoutPageData = async (): Promise<ICheckoutPage> => {
 
 export const fetchBookingPageData = async (): Promise<IBookingPage> => {
   const additionalSelections = `
+  ...,
   title,
   text
   `
@@ -117,6 +118,7 @@ export const fetchBookingPageData = async (): Promise<IBookingPage> => {
 
 export const fetchMenuPageData = async (): Promise<IMenuPage> => {
   const additionalSelections = `
+  ...,
   title,
   promo {
     text, 

--- a/src/server/sanity/sanity.utils.ts
+++ b/src/server/sanity/sanity.utils.ts
@@ -96,6 +96,7 @@ export const fetchGalleryPageData = async (): Promise<IGalleryPage> => {
 // Fetch checkoutPage with common selections
 export const fetchCheckoutPageData = async (): Promise<ICheckoutPage> => {
   const additionalSelections = `
+  ...,
   title,
   "checkoutImg": {
     "alt": coalesce(checkoutImg.alt, "No alt text"),

--- a/src/server/sanity/sanity.utils.ts
+++ b/src/server/sanity/sanity.utils.ts
@@ -82,6 +82,7 @@ export const fetchHomePageData = async (): Promise<IHomePage> => {
 // Fetch galleryPage with common selections
 export const fetchGalleryPageData = async (): Promise<IGalleryPage> => {
   const additionalSelections = `
+  ...,
   title,
   "galleryImgs": galleryImgs[]{
     "alt": coalesce(alt, "No alt text"),


### PR DESCRIPTION
## Problem

[Länka till ärendet här!](https://github.com/Examensarbete-Sebbe-Ellen-o-Linus/DinePal/issues/97)

## Lösning / Implementation
Det behövdes lägga till en metadata tag alternativt att lägga till en funktion från NextJS som kallas: "generateMetadata", i den hämtar vi seo informationen från sanity och ifall något går fel så använder vi bara "Dinepal" som en fallback.

