### PR TITLE
98 url builder for images

### DIFF
--- a/context/cartContext.tsx
+++ b/context/cartContext.tsx
@@ -81,6 +81,7 @@ export const CartProvider: React.FC<{ children: ReactNode }> = ({
         }
         return newCart;
       }, [] as CartItem[]);
+      setCartState(updatedCart);
       notificationMessage = `${quantityToAdd}x ${newDish.title} är nu tillagd i din varukorg.`;
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@preact/signals-react": "^2.0.0",
         "@prisma/client": "^5.6.0",
         "@sanity/client": "^6.10.0",
+        "@sanity/image-url": "^1.0.2",
         "@sanity/vision": "^3.23.4",
         "@t3-oss/env-nextjs": "^0.7.1",
         "@tanstack/react-query": "^4.36.1",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@preact/signals-react": "^2.0.0",
     "@prisma/client": "^5.6.0",
     "@sanity/client": "^6.10.0",
+    "@sanity/image-url": "^1.0.2",
     "@sanity/vision": "^3.23.4",
     "@t3-oss/env-nextjs": "^0.7.1",
     "@tanstack/react-query": "^4.36.1",

--- a/src/app/_components/about/About.tsx
+++ b/src/app/_components/about/About.tsx
@@ -1,16 +1,13 @@
 import { Box, Container, Text, Title } from '@mantine/core';
 import type { IAbout } from '~/app/interfaces';
+import CustomCropImage from '../customCropImage/CustomCropImage';
 import scss from './About.module.scss';
 
 export default async function About({ about }: { about: IAbout }) {
   return (
     <section className={scss.container} id='about'>
       <Container size={1120} fluid>
-        {about.image.url ? (
-          <img src={about.image.url} alt={about.image.alt} />
-        ) : (
-          <></>
-        )}
+        {about.image.url ? <CustomCropImage image={about.image} /> : <></>}
         <Box className={scss.text}>
           <Title order={3}>{about.title}</Title>
           <Text>{about.descriptionFirstP && about.descriptionFirstP}</Text>

--- a/src/app/_components/cartCard/CartCard.tsx
+++ b/src/app/_components/cartCard/CartCard.tsx
@@ -4,6 +4,7 @@ import { type CartItem } from 'context/initializers';
 import { useEffect, useState } from 'react';
 import { type IImage } from '~/app/interfaces';
 import { fetchSettingsData } from '~/server/sanity/sanity.utils';
+import CustomCropImage from '../customCropImage/CustomCropImage';
 import Quantity from '../quantityButton/QuantityButton';
 import { RemoveFromCartButton } from '../removeFromCart/removeFromCart';
 import classes from './CartCard.module.scss';
@@ -32,7 +33,7 @@ export default function CartCard({ item }: ICartCard) {
   return (
     <Box className={classes.container}>
       {item.dish.image.url ? (
-        <img src={item.dish.image.url} alt={item.dish.image.alt} />
+        <CustomCropImage image={item.dish.image} />
       ) : (
         <img src={logo?.url} alt={logo?.alt} className={classes.error} />
       )}

--- a/src/app/_components/checkoutCard/CheckoutCard.module.scss
+++ b/src/app/_components/checkoutCard/CheckoutCard.module.scss
@@ -14,6 +14,7 @@
 
 .imgContainer {
   max-width: 80px;
+  max-height: 80px;
   flex: 1 0 0;
   object-fit: cover;
   height: 100%;

--- a/src/app/_components/checkoutCard/CheckoutCard.tsx
+++ b/src/app/_components/checkoutCard/CheckoutCard.tsx
@@ -7,6 +7,7 @@ import { useEffect, useState } from 'react';
 import { formatPrice } from '~/app/formatPrice';
 import { type IImage } from '~/app/interfaces';
 import { fetchSettingsData } from '~/server/sanity/sanity.utils';
+import CustomCropImage from '../customCropImage/CustomCropImage';
 import Quantity from '../quantityButton/QuantityButton';
 import { RemoveFromCartButton } from '../removeFromCart/removeFromCart';
 import classes from './CheckoutCard.module.scss';
@@ -40,10 +41,9 @@ export default function CheckoutCard({ item }: ICheckoutCard) {
   return (
     <Box className={classes.container}>
       {item.dish.image.url ? (
-        <img
+        <CustomCropImage
+          image={item.dish.image}
           className={classes.imgContainer}
-          src={item.dish.image.url}
-          alt={item.dish.image.alt}
         />
       ) : (
         <img src={logo?.url} alt={logo?.alt} className={classes.error} />

--- a/src/app/_components/customCropImage/CustomCropImage.tsx
+++ b/src/app/_components/customCropImage/CustomCropImage.tsx
@@ -30,7 +30,6 @@ export default function CustomCropImage({ image, className, hotspot }: Props) {
     try {
       const imageObj = buildImageObj(image);
       src = urlFor(imageObj).url();
-      console.log('this works, image: ', image);
     } catch (error) {
       console.error('Error building image URL:', error);
     }

--- a/src/app/_components/customCropImage/CustomCropImage.tsx
+++ b/src/app/_components/customCropImage/CustomCropImage.tsx
@@ -7,7 +7,7 @@ interface Props {
   hotspot?: boolean;
 }
 
-const CustomCrop = ({ image, className, hotspot }: Props) => {
+const CustomCropImage = ({ image, className, hotspot }: Props) => {
   let src = image.url;
   console.log('this is the image: ', image);
   console.log('this is the image hotspot: ', image.hotspot);
@@ -52,4 +52,4 @@ const CustomCrop = ({ image, className, hotspot }: Props) => {
   );
 };
 
-export default CustomCrop;
+export default CustomCropImage;

--- a/src/app/_components/customCropImage/CustomCropImage.tsx
+++ b/src/app/_components/customCropImage/CustomCropImage.tsx
@@ -7,13 +7,15 @@ interface Props {
   hotspot?: boolean;
 }
 
-const CustomCropImage = ({ image, className, hotspot }: Props) => {
-  let src = image.url;
-  console.log('this is the image: ', image);
-  console.log('this is the image hotspot: ', image.hotspot);
-  console.log('this is the image crop: ', image.crop);
+export default function CustomCropImage({ image, className, hotspot }: Props) {
+  let src = '';
 
-  const customHotspot = (hotspot: IImage['hotspot']) => {
+  const customHotspot = (hotspot: {
+    x: number;
+    y: number;
+    width?: number;
+    height?: number;
+  }) => {
     if (!hotspot || !hotspot.x || !hotspot.y) {
       return { objectPosition: 'center' };
     }
@@ -24,32 +26,41 @@ const CustomCropImage = ({ image, className, hotspot }: Props) => {
 
   const hotspotStyle = hotspot ? customHotspot(image.hotspot) : {};
 
-  if (image.assetId) {
+  if (image && image.assetId) {
     try {
-      const hotspot = image.hotspot ?? { x: 0.5, y: 0.5 };
-      const crop = image.crop ?? { top: 0, bottom: 0, left: 0, right: 0 };
-      src = urlFor({ _id: image.assetId, crop, hotspot }).url();
-      // if (image.alt === 'Fork with pasta') {
-      //   console.log('This is the pasta image and url');
-      //   console.log(src);
-      // } else {
-      //   console.log('other images');
-      //   console.log(src);
-      // }
+      const imageObj = buildImageObj(image);
+      src = urlFor(imageObj).url();
+      console.log('this works, image: ', image);
     } catch (error) {
       console.error('Error building image URL:', error);
     }
+  } else if (image && image.url) {
+    src = image.url;
   } else {
-    console.log('No image assetId found for image:', image);
+    console.log('No assetId or url was found for image:', image);
   }
+
   return (
     <img
       className={className}
       src={src}
-      alt={image.alt ?? 'Default alt text'}
+      alt={image?.alt ?? 'Default alt text'}
       style={hotspotStyle}
     />
   );
-};
+}
 
-export default CustomCropImage;
+export function buildImageObj(source: IImage) {
+  const imageObj: {
+    asset: { _ref: string };
+    crop?: IImage['crop'];
+    hotspot?: IImage['hotspot'];
+  } = {
+    asset: { _ref: source.assetId },
+  };
+
+  if (source.crop) imageObj.crop = source.crop;
+  if (source.hotspot) imageObj.hotspot = source.hotspot;
+
+  return imageObj;
+}

--- a/src/app/_components/customImage/CustomCrop.tsx
+++ b/src/app/_components/customImage/CustomCrop.tsx
@@ -1,0 +1,55 @@
+import { type IImage } from '~/app/interfaces';
+import { urlFor } from '~/server/sanity/sanity.utils';
+
+interface Props {
+  image: IImage;
+  className?: string;
+  hotspot?: boolean;
+}
+
+const CustomCrop = ({ image, className, hotspot }: Props) => {
+  let src = image.url;
+  console.log('this is the image: ', image);
+  console.log('this is the image hotspot: ', image.hotspot);
+  console.log('this is the image crop: ', image.crop);
+
+  const customHotspot = (hotspot: IImage['hotspot']) => {
+    if (!hotspot || !hotspot.x || !hotspot.y) {
+      return { objectPosition: 'center' };
+    }
+    return {
+      objectPosition: `${hotspot.x * 100}% ${hotspot.y * 100}%`,
+    };
+  };
+
+  const hotspotStyle = hotspot ? customHotspot(image.hotspot) : {};
+
+  if (image.assetId) {
+    try {
+      const hotspot = image.hotspot ?? { x: 0.5, y: 0.5 };
+      const crop = image.crop ?? { top: 0, bottom: 0, left: 0, right: 0 };
+      src = urlFor({ _id: image.assetId, crop, hotspot }).url();
+      // if (image.alt === 'Fork with pasta') {
+      //   console.log('This is the pasta image and url');
+      //   console.log(src);
+      // } else {
+      //   console.log('other images');
+      //   console.log(src);
+      // }
+    } catch (error) {
+      console.error('Error building image URL:', error);
+    }
+  } else {
+    console.log('No image assetId found for image:', image);
+  }
+  return (
+    <img
+      className={className}
+      src={src}
+      alt={image.alt ?? 'Default alt text'}
+      style={hotspotStyle}
+    />
+  );
+};
+
+export default CustomCrop;

--- a/src/app/_components/dishCard/DishCard.module.scss
+++ b/src/app/_components/dishCard/DishCard.module.scss
@@ -1,6 +1,6 @@
 .card {
   display: flex;
-  width: 328px;
+  width: 326px;
   padding: 16px;
   flex-direction: column;
   align-items: flex-start;

--- a/src/app/_components/dishCard/DishCard.tsx
+++ b/src/app/_components/dishCard/DishCard.tsx
@@ -17,7 +17,6 @@ interface Props {
 export default function DishCard({ dish }: Props) {
   const { handleAddToCart } = useCart();
   const menuLink = `/menu#${dish?.slug?.current ?? '/menu'}`;
-  console.log('dish image:', dish.image);
 
   return (
     <Box className={classes.card} id={dish.slug.current}>

--- a/src/app/_components/dishCard/DishCard.tsx
+++ b/src/app/_components/dishCard/DishCard.tsx
@@ -5,7 +5,7 @@ import { useCart } from 'context/cartContext';
 import Link from 'next/link';
 import type { IDish } from '~/app/interfaces';
 import AddButton from '../addButton/AddButton';
-import CustomCrop from '../customImage/CustomCrop';
+import CustomCropImage from '../customCropImage/CustomCropImage';
 import PlaceholderSmall from '../placeholderSmall/PlaceholderSmall';
 import Tags from '../tags/Tags';
 import classes from './DishCard.module.scss';
@@ -23,7 +23,7 @@ export default function DishCard({ dish }: Props) {
     <Box className={classes.card} id={dish.slug.current}>
       <Link href={menuLink}>
         {dish.image?.url ? (
-          <CustomCrop image={dish.image} className={classes.image} />
+          <CustomCropImage image={dish.image} className={classes.image} />
         ) : (
           <PlaceholderSmall hover={true} />
         )}

--- a/src/app/_components/dishCard/DishCard.tsx
+++ b/src/app/_components/dishCard/DishCard.tsx
@@ -8,7 +8,6 @@ import Tags from '../tags/Tags';
 import classes from './DishCard.module.scss';
 
 interface Props {
-  showDescription: boolean;
   dish: IDish;
 }
 
@@ -38,7 +37,6 @@ export default function DishCard({ showDescription, dish }: Props) {
             </Link>
             <Text>{dish.price}:-</Text>
           </Box>
-          {showDescription && <Text>{dish.description}</Text>}
         </Box>
         <Box className={classes.bottom}>
           <Box className={classes.iconContainer}>

--- a/src/app/_components/dishCard/DishCard.tsx
+++ b/src/app/_components/dishCard/DishCard.tsx
@@ -1,8 +1,11 @@
+'use client';
+
 import { Box, Divider, Text, Title } from '@mantine/core';
 import { useCart } from 'context/cartContext';
 import Link from 'next/link';
 import type { IDish } from '~/app/interfaces';
 import AddButton from '../addButton/AddButton';
+import CustomCrop from '../customImage/CustomCrop';
 import PlaceholderSmall from '../placeholderSmall/PlaceholderSmall';
 import Tags from '../tags/Tags';
 import classes from './DishCard.module.scss';
@@ -11,24 +14,20 @@ interface Props {
   dish: IDish;
 }
 
-export default function DishCard({ showDescription, dish }: Props) {
+export default function DishCard({ dish }: Props) {
   const { handleAddToCart } = useCart();
   const menuLink = `/menu#${dish?.slug?.current ?? '/menu'}`;
+  console.log('dish image:', dish.image);
 
   return (
     <Box className={classes.card} id={dish.slug.current}>
       <Link href={menuLink}>
-        {dish.image.url ? (
-          <img
-            className={classes.image}
-            src={dish.image.url}
-            alt={dish.image.alt}
-          />
+        {dish.image?.url ? (
+          <CustomCrop image={dish.image} className={classes.image} />
         ) : (
           <PlaceholderSmall hover={true} />
         )}
       </Link>
-
       <Box className={classes.top}>
         <Box className={classes.textTop}>
           <Box className={classes.headingPrice}>

--- a/src/app/_components/imageSection/ImageSection.module.scss
+++ b/src/app/_components/imageSection/ImageSection.module.scss
@@ -38,6 +38,7 @@
       width: 352px;
       height: 480px;
       transition: transform 0.5s ease;
+      background-color: rgb(28, 26, 26);
 
       @media (max-width: $mantine-breakpoint-sm) {
         width: 100%;

--- a/src/app/_components/menuContent/MenuContent.tsx
+++ b/src/app/_components/menuContent/MenuContent.tsx
@@ -1,9 +1,9 @@
 'use client';
 import { Box, Container, MultiSelect, Text, Title } from '@mantine/core';
 import { useEffect, useState } from 'react';
-import { IDish, IMenuPage } from '~/app/interfaces';
+import { type IDish, type IMenuPage } from '~/app/interfaces';
 import MenuDishCard from '../menuDishCard/MenuDishCard';
-import { IconKey, tagDetails } from '../tags/Tags';
+import { tagDetails, type IconKey } from '../tags/Tags';
 import scss from './menuContent.module.scss';
 
 interface Props {

--- a/src/app/_components/menuDishCard/MenuDishCard.tsx
+++ b/src/app/_components/menuDishCard/MenuDishCard.tsx
@@ -9,8 +9,6 @@ import classes from './MenuDishCard.module.scss';
 
 export default function MenuDishCard({ dish }: { dish: IDish }) {
   const { handleAddToCart } = useCart();
-  console.log('dish object:', dish);
-  console.log('dish.image:', dish.image);
 
   return (
     <Box className={classes.card} id={dish.slug.current}>

--- a/src/app/_components/menuDishCard/MenuDishCard.tsx
+++ b/src/app/_components/menuDishCard/MenuDishCard.tsx
@@ -2,7 +2,7 @@ import { Box, Divider, Text, Title } from '@mantine/core';
 import { useCart } from 'context/cartContext';
 import type { IDish } from '~/app/interfaces';
 import AddButton from '../addButton/AddButton';
-import CustomCrop from '../customImage/CustomCrop';
+import CustomCropImage from '../customCropImage/CustomCropImage';
 import PlaceholderSmall from '../placeholderSmall/PlaceholderSmall';
 import Tags from '../tags/Tags';
 import classes from './MenuDishCard.module.scss';
@@ -16,7 +16,7 @@ export default function MenuDishCard({ dish }: { dish: IDish }) {
     <Box className={classes.card} id={dish.slug.current}>
       {dish.image?.url ? (
         <Box>
-          <CustomCrop image={dish.image} className={classes.image} />
+          <CustomCropImage image={dish.image} className={classes.image} />
         </Box>
       ) : (
         <PlaceholderSmall />

--- a/src/app/_components/menuDishCard/MenuDishCard.tsx
+++ b/src/app/_components/menuDishCard/MenuDishCard.tsx
@@ -2,22 +2,21 @@ import { Box, Divider, Text, Title } from '@mantine/core';
 import { useCart } from 'context/cartContext';
 import type { IDish } from '~/app/interfaces';
 import AddButton from '../addButton/AddButton';
+import CustomCrop from '../customImage/CustomCrop';
 import PlaceholderSmall from '../placeholderSmall/PlaceholderSmall';
 import Tags from '../tags/Tags';
 import classes from './MenuDishCard.module.scss';
 
 export default function MenuDishCard({ dish }: { dish: IDish }) {
   const { handleAddToCart } = useCart();
+  console.log('dish object:', dish);
+  console.log('dish.image:', dish.image);
 
   return (
     <Box className={classes.card} id={dish.slug.current}>
-      {dish.image.url ? (
+      {dish.image?.url ? (
         <Box>
-          <img
-            className={classes.image}
-            src={dish.image.url}
-            alt={dish.image.alt}
-          />
+          <CustomCrop image={dish.image} className={classes.image} />
         </Box>
       ) : (
         <PlaceholderSmall />

--- a/src/app/_components/selectedDishes/SelectedDishes.tsx
+++ b/src/app/_components/selectedDishes/SelectedDishes.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { Box, Container, Text, Title } from '@mantine/core';
 import Link from 'next/link';
 import type { IDish } from '../../interfaces';
@@ -13,7 +11,7 @@ export default function SelectedDishes({ dishes }: { dishes: IDish[] }) {
       <Box className={scss.grid}>
         <Title order={2}>Favoriter</Title>
         {dishes.map((dish, i) => (
-          <DishCard key={i} showDescription={false} dish={dish} />
+          <DishCard key={i} dish={dish} />
         ))}
         <Box className={scss.information}>
           <Text>

--- a/src/app/gallery/page.tsx
+++ b/src/app/gallery/page.tsx
@@ -1,6 +1,6 @@
 import { Container, Title } from '@mantine/core';
 import { fetchGalleryPageData } from '../../server/sanity/sanity.utils';
-import CustomCrop from '../_components/customImage/CustomCrop';
+import CustomCropImage from '../_components/customCropImage/CustomCropImage';
 import scss from './page.module.scss';
 
 export default async function GalleryPage() {
@@ -35,7 +35,7 @@ export default async function GalleryPage() {
           return (
             <div key={index} className={scss.col} style={style}>
               {image.url && (
-                <CustomCrop image={image} className={scss.image} hotspot />
+                <CustomCropImage image={image} className={scss.image} hotspot />
               )}
             </div>
           );

--- a/src/app/gallery/page.tsx
+++ b/src/app/gallery/page.tsx
@@ -1,5 +1,6 @@
 import { Container, Title } from '@mantine/core';
 import { fetchGalleryPageData } from '../../server/sanity/sanity.utils';
+import CustomCrop from '../_components/customImage/CustomCrop';
 import scss from './page.module.scss';
 
 export default async function GalleryPage() {
@@ -33,7 +34,9 @@ export default async function GalleryPage() {
           };
           return (
             <div key={index} className={scss.col} style={style}>
-              <img src={image.url} alt={image.alt} className={scss.image} />
+              {image.url && (
+                <CustomCrop image={image} className={scss.image} hotspot />
+              )}
             </div>
           );
         })}

--- a/src/app/interfaces.ts
+++ b/src/app/interfaces.ts
@@ -4,6 +4,21 @@ export interface IImage {
   url: string;
   alt?: string;
   link?: IButton;
+  assetId: string;
+  hotspot: {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+  };
+  crop: {
+    top: number;
+    left: number;
+    bottom: number;
+    right: number;
+    width: number;
+    height: number;
+  };
 }
 
 // Button interface

--- a/src/server/sanity/sanity.utils.ts
+++ b/src/server/sanity/sanity.utils.ts
@@ -1,6 +1,8 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/restrict-plus-operands */
 /* eslint-disable @typescript-eslint/no-unsafe-return */
+import imageUrlBuilder from '@sanity/image-url'
+import {type SanityImageSource} from '@sanity/image-url/lib/types/types'
 import {createClient} from 'next-sanity'
 import type {
   IBookingPage,
@@ -40,12 +42,21 @@ const buttonSelection = `
   }
 `
 
+const builder = imageUrlBuilder(client)
+
+export function urlFor(source: SanityImageSource) {
+  return builder.image(source)
+}
+
 // Common selection for images nested in other documents
 const imageSelection = `
   "image": {
     "alt": coalesce(image.alt, "No alt text"),
     "url": image.asset->url,
-    "_key": string,
+    "assetId": image.asset._ref,
+    "_key": image._key,
+    "hotspot": image.hotspot,
+    "crop": image.crop,
   }
 `
 
@@ -55,7 +66,7 @@ const imageSelection = `
 export const fetchHomePageData = async (): Promise<IHomePage> => {
   const additionalSelections = `
       title,
-      hero { title, ${imageSelection}, ${buttonSelection}, description },
+      hero { title, ${imageSelection}, ${buttonSelection} },
       selectedDishes[]-> { title, description, price, slug, ${imageSelection}, tags[] },
       imageSection { 
         title, 
@@ -82,12 +93,16 @@ export const fetchHomePageData = async (): Promise<IHomePage> => {
 // Fetch galleryPage with common selections
 export const fetchGalleryPageData = async (): Promise<IGalleryPage> => {
   const additionalSelections = `
+  ...,
   title,
-  "galleryImgs": galleryImgs[]{
+  galleryImgs[]{
     "alt": coalesce(alt, "No alt text"),
     "url": asset->url,
-    "key": _key
-  }  
+    "assetId": asset._ref,
+    "key": _key,
+    hotspot,
+    crop,
+  }
   `
   return fetchDocumentById('galleryPage', additionalSelections)
 }
@@ -98,10 +113,10 @@ export const fetchCheckoutPageData = async (): Promise<ICheckoutPage> => {
   title,
   "checkoutImg": {
     "alt": coalesce(checkoutImg.alt, "No alt text"),
-    "url": checkoutImg.asset->url
-  }
-
-  
+    "url": checkoutImg.asset->url,
+    crop,
+    hotspot
+  }  
   `
   return fetchDocumentById('checkoutPage', additionalSelections)
 }
@@ -120,6 +135,9 @@ export const fetchMenuPageData = async (): Promise<IMenuPage> => {
   promo {
     text, 
     button
+  },
+  seo {
+    metaTitle, ...
   }
   `
   return fetchDocumentById('menuPage', additionalSelections)
@@ -132,9 +150,12 @@ export const fetchDishes = async (): Promise<IDish[]> => {
       slug,
       description,
       "image": {
+        "assetId": image.asset._ref,
         "alt": coalesce(image.alt, "No alt text"),
         "url": image.asset->url,
-        "_key": image._key
+        "_key": image._key,
+        "hotspot": image.hotspot,
+        "crop": image.crop,
       },
       price,
       tags[]
@@ -154,6 +175,7 @@ export const fetchSingleDish = async (slug: string): Promise<IDish> => {
     "image": {
       "alt": coalesce(image.alt, "No alt text"),
       "url": image.asset->url,
+      "hotspot": {...}, 
     },    
     price,
     tags[]

--- a/src/server/sanity/schemas/objects/imageSection.ts
+++ b/src/server/sanity/schemas/objects/imageSection.ts
@@ -24,9 +24,6 @@ export default defineType({
               name: 'image',
               title: 'Image',
               type: 'image',
-              options: {
-                hotspot: true,
-              },
             }),
             {
               name: 'alt',


### PR DESCRIPTION
## Problem

Bilderna på sidan speglade inte de inställningarna man har satt i sanity studio med crop och hotspot.
I en tidigare merge försvann en del ur cartContext som gjorde att varukorgen inte uppdaterades korrekt.

## Lösning / Implementation

Installerat en sanity url bilder som generar en src beroende på vilka inställningar man ställt in i studion. 
Det var problematiskt att applicera både hotspot och crop på dishCard/menuCard för proportionerna blev inte riktigt rätt så jag skapade en prop med hotspot som används på bilderna i galleriet. 
Nu används CustomCropImage i cart, checkout, dishcard, menucard och i galleriet. 

CustomCart är fixad så att den uppdaterar cart-statet.

## Testning
Bilderna i kassan, varukorgen, selected dishes, meny och galleriet ska ha crop inställningar. 
Lättast att se är på bilden som har namnet "testa crop" där man ska få med enbart ansiktet på bilden. 
I galleriet ser man om det appliceras genom att gaffelns top alltid är i bild oavsett skärmstorlek.

<img width="313" alt="Skärmavbild 2024-01-23 kl  14 04 16" src="https://github.com/Examensarbete-Sebbe-Ellen-o-Linus/DinePal/assets/80984009/7ff69c3b-001a-4ec9-a449-dbd4a604f55d">

<img width="557" alt="Skärmavbild 2024-01-23 kl  14 04 47" src="https://github.com/Examensarbete-Sebbe-Ellen-o-Linus/DinePal/assets/80984009/0669bf78-6b97-4ef7-9c76-f1e532b7cf9e">

<img width="722" alt="Skärmavbild 2024-01-23 kl  14 04 32" src="https://github.com/Examensarbete-Sebbe-Ellen-o-Linus/DinePal/assets/80984009/6b6c2b55-831f-41b9-960a-78ad4e29da50">

<img width="680" alt="Skärmavbild 2024-01-23 kl  14 11 09" src="https://github.com/Examensarbete-Sebbe-Ellen-o-Linus/DinePal/assets/80984009/c4620f69-f9ac-4ae5-b056-2c7311c8da15">
