### PR TITLE
99 make images and text smaller

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,6 @@
         "next-auth": "^4.24.5",
         "next-sanity": "^7.0.6",
         "polished": "^4.2.2",
-        "prettier": "^3.1.1",
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "react-time-ago": "^7.2.1",
@@ -56,6 +55,7 @@
         "postcss": "^8.4.32",
         "postcss-preset-mantine": "^1.12.3",
         "postcss-simple-vars": "^7.0.1",
+        "prettier": "^3.2.4",
         "prisma": "^5.6.0",
         "sass": "^1.69.7",
         "typescript": "^5.1.6"
@@ -2055,7 +2055,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@sanity/image-url/-/image-url-1.0.2.tgz",
       "integrity": "sha512-C4+jb2ny3ZbMgEkLd7Z3C75DsxcTEoE+axXQJsQ75ou0AKWGdVsP351hqK6mJUUxn5HCSlu3vznoh7Yljye4cQ==",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       }
@@ -8301,9 +8300,10 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.1.1.tgz",
-      "integrity": "sha512-22UbSzg8luF4UuZtzgiUOfcGM8s4tjBv6dJRT7j275NXsy2jb4aJa4NNveul5x4eqlF1wuhuR2RElK71RvmVaw==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.4.tgz",
+      "integrity": "sha512-FWu1oLHKCrtpO1ypU6J0SbK2d9Ckwysq6bHj/uaCP26DxrPpppCLQRGVuqAxSTvhF00AcvDRyYrLNW7ocBhFFQ==",
+      "dev": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "next-auth": "^4.24.5",
     "next-sanity": "^7.0.6",
     "polished": "^4.2.2",
-    "prettier": "^3.1.1",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-time-ago": "^7.2.1",
@@ -62,6 +61,7 @@
     "postcss": "^8.4.32",
     "postcss-preset-mantine": "^1.12.3",
     "postcss-simple-vars": "^7.0.1",
+    "prettier": "^3.2.4",
     "prisma": "^5.6.0",
     "sass": "^1.69.7",
     "typescript": "^5.1.6"

--- a/src/app/_components/addButton/AddButton.module.scss
+++ b/src/app/_components/addButton/AddButton.module.scss
@@ -2,7 +2,7 @@
 
 .container {
   display: flex;
-  padding: 8px 80px;
+  padding: 8px 0;
   justify-content: center;
   align-items: center;
   gap: 8px;

--- a/src/app/_components/dishCard/DishCard.module.scss
+++ b/src/app/_components/dishCard/DishCard.module.scss
@@ -1,3 +1,5 @@
+@import '../../../styles/mantine';
+
 .card {
   display: flex;
   max-width:100%;
@@ -34,6 +36,14 @@
   align-items: center;
   justify-content: center;
 
+  @media (max-width: $mantine-breakpoint-xs) {
+    height: 360px;
+  }
+
+  @media (max-width: 400px) {
+    height: 240px;
+  }
+
   @media (hover: hover) {
     &:hover {
       transform: translateY(-24px);
@@ -55,6 +65,10 @@
   flex-direction: column;
   gap: 16px;
   margin-bottom: 16px;
+
+  @media (max-width: $mantine-breakpoint-xs) {
+
+  }
 }
 
 .headingPrice {
@@ -68,3 +82,4 @@
   display: flex;
   gap: 8px;
 }
+

--- a/src/app/_components/dishCard/DishCard.module.scss
+++ b/src/app/_components/dishCard/DishCard.module.scss
@@ -5,7 +5,6 @@
   max-width:100%;
   padding: 16px;
   flex-direction: column;
-  align-items: flex-start;
   justify-content: center;
   gap: 16px;
   border-radius: var(--mantine-radius-primary);

--- a/src/app/_components/dishCard/DishCard.module.scss
+++ b/src/app/_components/dishCard/DishCard.module.scss
@@ -2,7 +2,6 @@
 
 .card {
   display: flex;
-  max-width:100%;
   padding: 16px;
   flex-direction: column;
   justify-content: center;
@@ -64,10 +63,6 @@
   flex-direction: column;
   gap: 16px;
   margin-bottom: 16px;
-
-  @media (max-width: $mantine-breakpoint-xs) {
-
-  }
 }
 
 .headingPrice {

--- a/src/app/_components/dishCard/DishCard.module.scss
+++ b/src/app/_components/dishCard/DishCard.module.scss
@@ -71,4 +71,3 @@
   display: flex;
   gap: 8px;
 }
-

--- a/src/app/_components/dishCard/DishCard.module.scss
+++ b/src/app/_components/dishCard/DishCard.module.scss
@@ -1,9 +1,10 @@
 .card {
   display: flex;
-  width: 328px;
+  max-width:100%;
   padding: 16px;
   flex-direction: column;
   align-items: flex-start;
+  justify-content: center;
   gap: 16px;
   border-radius: var(--mantine-radius-primary);
   background: var(--mantine-color-white-0);
@@ -20,8 +21,8 @@
 }
 
 .image {
-  height: 326px;
-  width: 300px;
+  height: 240px;
+  width: 100%;
   border-radius: var(--mantine-radius-primary);
   transition:
     transform 0.3s ease,
@@ -65,13 +66,5 @@
 
 .iconContainer {
   display: flex;
-  flex-direction: row;
-  align-items: flex-start;
   gap: 8px;
-  align-self: stretch;
-}
-
-.line {
-  width: 296px;
-  height: 1px;
 }

--- a/src/app/_components/footer/Footer.module.scss
+++ b/src/app/_components/footer/Footer.module.scss
@@ -93,7 +93,7 @@
 }
 
 .copyRight {
-  font-size: 14px !important;
+  font-size: 13px !important;
 }
 
 .socialMedia {

--- a/src/app/_components/footer/Footer.module.scss
+++ b/src/app/_components/footer/Footer.module.scss
@@ -77,15 +77,14 @@
 .lowerContainer {
   display: flex;
   width: 100%;
-  padding-bottom: 16px;
   justify-content: space-between;
   align-items: flex-end;
 
   @media (max-width: $mantine-breakpoint-md) {
-    padding: 0 32px;
+    padding: 0 32px 32px;
   }
   @media (max-width: $mantine-breakpoint-sm) {
-    padding: 0 32px 60px;
+    padding: 0 32px;
     flex-direction: column;
     align-items: center;
     gap: 8px;

--- a/src/app/_components/header/Header.tsx
+++ b/src/app/_components/header/Header.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { Box, Burger, Drawer, Image } from '@mantine/core';
+import { Box, Burger, Drawer, Image, Title } from '@mantine/core';
 import { useDisclosure, useMediaQuery } from '@mantine/hooks';
 
 import Link from 'next/link';
@@ -60,7 +60,9 @@ export default function Header({ header }: { header: IHeader }) {
                     href={generateUrl(navLink.pageType)}
                     onClick={closeDrawer}
                   >
-                    {navLink.text}
+                    <Title className={classes.link} order={6}>
+                      {navLink.text}
+                    </Title>
                   </Link>
                 </React.Fragment>
               ))}

--- a/src/app/_components/imageSection/ImageSection.module.scss
+++ b/src/app/_components/imageSection/ImageSection.module.scss
@@ -6,17 +6,26 @@
   background: var(--mantine-color-black-3);
   display: flex;
   margin-bottom: calc(198px - 35px);
-
+ 
   @media (max-width: $mantine-breakpoint-sm) {
     transform: none;
     margin-top: 273px;
     margin-bottom: 0;
   }
 
+  .innerContainer {
+    padding: 0 32px;
+
+    @media (max-width: $mantine-breakpoint-sm) {
+      padding: 0;
+    }
+  }
+
   > div {
     display: inline-flex;
     align-items: flex-start;
     gap: 34px;
+
 
     @media (max-width: $mantine-breakpoint-sm) {
       flex-wrap: wrap;
@@ -35,13 +44,12 @@
 
     .imageCard {
       position: relative;
-      width: 352px;
-      height: 480px;
+      width: 100%;
+      height: 440px;
       transition: transform 0.5s ease;
 
       @media (max-width: $mantine-breakpoint-sm) {
         width: 100%;
-        height: 480px;
       }
 
       &:nth-of-type(1) {

--- a/src/app/_components/imageSection/ImageSection.module.scss
+++ b/src/app/_components/imageSection/ImageSection.module.scss
@@ -6,7 +6,7 @@
   background: var(--mantine-color-black-3);
   display: flex;
   margin-bottom: calc(198px - 35px);
- 
+
   @media (max-width: $mantine-breakpoint-sm) {
     transform: none;
     margin-top: 273px;
@@ -25,7 +25,6 @@
     display: inline-flex;
     align-items: flex-start;
     gap: 34px;
-
 
     @media (max-width: $mantine-breakpoint-sm) {
       flex-wrap: wrap;

--- a/src/app/_components/imageSection/ImageSection.tsx
+++ b/src/app/_components/imageSection/ImageSection.tsx
@@ -10,7 +10,7 @@ export default function ImageSection({
 }) {
   return (
     <div className={scss.container}>
-      <Container size={1120} fluid>
+      <Container className={scss.innerContainer} maw={1120} fluid>
         {imageSection.imageCards?.map((image, i) => (
           <Box className={scss.imageCard} key={i}>
             {image.link && (

--- a/src/app/_components/menuContent/MenuContent.tsx
+++ b/src/app/_components/menuContent/MenuContent.tsx
@@ -1,9 +1,9 @@
 'use client';
 import { Box, Container, MultiSelect, Text, Title } from '@mantine/core';
 import { useEffect, useState } from 'react';
-import { IDish, IMenuPage } from '~/app/interfaces';
+import { type IDish, type IMenuPage } from '~/app/interfaces';
 import MenuDishCard from '../menuDishCard/MenuDishCard';
-import { IconKey, tagDetails } from '../tags/Tags';
+import { tagDetails, type IconKey } from '../tags/Tags';
 import scss from './menuContent.module.scss';
 
 interface Props {
@@ -74,7 +74,7 @@ export default function MenuContent({ dishes, menu }: Props) {
 
   return (
     <>
-      <Container size={1120} className={scss.container}>
+      <Container maw={1120} className={scss.container}>
         <Box className={scss.grid}>
           <Box className={` ${!filterVisible ? scss.hideTop : scss.filterTop}`}>
             <Box>

--- a/src/app/_components/menuContent/menuContent.module.scss
+++ b/src/app/_components/menuContent/menuContent.module.scss
@@ -2,6 +2,7 @@
 
 .container {
   padding: 48px 32px;
+
   @media (max-width: $mantine-breakpoint-sm) {
     padding: 0 16px 48px;
   }
@@ -61,7 +62,6 @@
   margin: 0 auto; 
   grid-template-columns: repeat(4, minmax(0, 1fr)); 
   gap: 32px 24px;
-  // justify-content: center;
 
   @media (max-width: $mantine-breakpoint-lg) {
     grid-template-columns: repeat(3, minmax(0, 1fr));

--- a/src/app/_components/menuContent/menuContent.module.scss
+++ b/src/app/_components/menuContent/menuContent.module.scss
@@ -59,8 +59,8 @@
 
 .grid {
   display: grid;
-  margin: 0 auto; 
-  grid-template-columns: repeat(4, minmax(0, 1fr)); 
+  margin: 0 auto;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
   gap: 32px 24px;
 
   @media (max-width: $mantine-breakpoint-lg) {
@@ -72,7 +72,7 @@
     margin-top: 250px;
   }
 
-  @media (max-width:  $mantine-breakpoint-xs) {
+  @media (max-width: $mantine-breakpoint-xs) {
     grid-template-columns: repeat(1, minmax(0, 1fr));
   }
 }

--- a/src/app/_components/menuContent/menuContent.module.scss
+++ b/src/app/_components/menuContent/menuContent.module.scss
@@ -1,9 +1,9 @@
 @import '../../../styles/mantine';
 
 .container {
-  padding: 48px 0;
+  padding: 48px 32px;
   @media (max-width: $mantine-breakpoint-sm) {
-    padding: 0 0 48px 0;
+    padding: 0 16px 48px;
   }
 
   h2 {
@@ -58,17 +58,22 @@
 
 .grid {
   display: grid;
-  grid-template-columns: repeat(3, 328px);
+  margin: 0 auto; 
+  grid-template-columns: repeat(4, minmax(0, 1fr)); 
   gap: 32px 24px;
-  justify-content: center;
+  // justify-content: center;
 
   @media (max-width: $mantine-breakpoint-lg) {
-    grid-template-columns: repeat(2, 328px);
+    grid-template-columns: repeat(3, minmax(0, 1fr));
   }
 
   @media (max-width: $mantine-breakpoint-sm) {
-    grid-template-columns: repeat(1, 328px);
+    grid-template-columns: repeat(2, minmax(0, 1fr));
     margin-top: 250px;
+  }
+
+  @media (max-width:  $mantine-breakpoint-xs) {
+    grid-template-columns: repeat(1, minmax(0, 1fr));
   }
 }
 

--- a/src/app/_components/menuDishCard/MenuDishCard.module.scss
+++ b/src/app/_components/menuDishCard/MenuDishCard.module.scss
@@ -1,6 +1,7 @@
+@import '../../../styles/mantine';
+
 .card {
   display: flex;
-  width: 328px;
   padding: 16px;
   flex-direction: column;
   align-items: flex-start;
@@ -20,8 +21,8 @@
 }
 
 .image {
-  height: 326px;
-  width: 300px;
+  height: 240px;
+  width: 100%;
   border-radius: var(--mantine-radius-primary);
   transition:
     transform 0.3s ease,
@@ -32,6 +33,14 @@
   display: flex;
   align-items: center;
   justify-content: center;
+
+  @media (max-width: $mantine-breakpoint-xs) {
+    height: 360px;
+  }
+
+  @media (max-width: 400px) {
+    height: 240px;
+  }
 }
 
 .top {

--- a/src/app/_components/menuDishCard/MenuDishCard.module.scss
+++ b/src/app/_components/menuDishCard/MenuDishCard.module.scss
@@ -56,7 +56,7 @@
 .headingPrice {
   display: flex;
   justify-content: space-between;
-  align-items: flex-end;
+  align-items: flex-start;
   align-self: stretch;
 }
 

--- a/src/app/_components/menuDishCard/MenuDishCard.module.scss
+++ b/src/app/_components/menuDishCard/MenuDishCard.module.scss
@@ -36,7 +36,6 @@
   display: flex;
   align-items: center;
   justify-content: center;
-
 }
 
 .top {

--- a/src/app/_components/news/News.module.scss
+++ b/src/app/_components/news/News.module.scss
@@ -2,9 +2,8 @@
 
 .container {
   display: flex;
-  padding: 60px 32px 120px;
+  padding: 120px 32px 120px;
   gap: 2rem;
-  margin-top: 60px;
 
   @media (max-width: $mantine-breakpoint-md) {
     flex-direction: column;

--- a/src/app/_components/news/News.module.scss
+++ b/src/app/_components/news/News.module.scss
@@ -27,7 +27,7 @@
   }
 
   img {
-    height: 840px;
+    height: 624px;
     border-radius: var(--mantine-radius-primary);
     object-fit: cover;
     flex: 1 0 0;

--- a/src/app/_components/placeholderSmall/placeholderSmall.module.scss
+++ b/src/app/_components/placeholderSmall/placeholderSmall.module.scss
@@ -1,8 +1,8 @@
 .placeholder {
   display: flex;
   border-radius: var(--mantine-radius-primary);
-  height: 376px;
-  width: 300px;
+  height: 264px;
+  width: 240px;
 
   .inner {
     background: var(--mantine-color-white-0);

--- a/src/app/_components/placeholderSmall/placeholderSmall.module.scss
+++ b/src/app/_components/placeholderSmall/placeholderSmall.module.scss
@@ -1,8 +1,10 @@
+@import '../../../styles/mantine';
+
 .placeholder {
   display: flex;
   border-radius: var(--mantine-radius-primary);
-  height: 264px;
-  width: 240px;
+  height: 240px;
+  border: 1px solid red;
 
   .inner {
     background: var(--mantine-color-white-0);
@@ -13,9 +15,7 @@
     flex-direction: column;
     filter: grayscale(1);
     gap: 32px;
-    height: 100%;
     width: 100%;
-    height: 326px;
     border-bottom: 1px solid var(--mantine-color-gray-4);
     transition:
       transform 0.3s ease,

--- a/src/app/_components/placeholderSmall/placeholderSmall.module.scss
+++ b/src/app/_components/placeholderSmall/placeholderSmall.module.scss
@@ -4,6 +4,7 @@
   display: flex;
   border-radius: var(--mantine-radius-primary);
   height: 240px;
+  width: 100%;
 
   .inner {
     background: var(--mantine-color-white-0);
@@ -14,6 +15,7 @@
     flex-direction: column;
     filter: grayscale(1);
     gap: 32px;
+    height: 240px;
     width: 100%;
     border-bottom: 1px solid var(--mantine-color-gray-4);
     transition:

--- a/src/app/_components/placeholderSmall/placeholderSmall.module.scss
+++ b/src/app/_components/placeholderSmall/placeholderSmall.module.scss
@@ -4,7 +4,6 @@
   display: flex;
   border-radius: var(--mantine-radius-primary);
   height: 240px;
-  border: 1px solid red;
 
   .inner {
     background: var(--mantine-color-white-0);

--- a/src/app/_components/promo/Promo.tsx
+++ b/src/app/_components/promo/Promo.tsx
@@ -31,16 +31,18 @@ export default function Promo() {
         {!error ? (
           promo && (
             <>
-              <Title order={6} className={scss.text}>
-                {promo.text}
-              </Title>
-              <LongButton
-                text={promo.button?.text ?? 'Default Text'}
-                color={'orange'}
-                onClick={() =>
-                  (window.location.href = `/${promo.button?.pageType}`)
-                }
-              />
+              <Box className={scss.innerContainer}>
+                <Title order={6} className={scss.text}>
+                  {promo.text}
+                </Title>
+                <LongButton
+                  text={promo.button?.text ?? 'Default Text'}
+                  color={'orange'}
+                  onClick={() =>
+                    (window.location.href = `/${promo.button?.pageType}`)
+                  }
+                />
+              </Box>
             </>
           )
         ) : (

--- a/src/app/_components/promo/Promo.tsx
+++ b/src/app/_components/promo/Promo.tsx
@@ -27,7 +27,7 @@ export default function Promo() {
 
   return (
     <Box className={scss.container}>
-      <Container size={1120}>
+      <Container p={0} maw={1120}>
         {!error ? (
           promo && (
             <>

--- a/src/app/_components/promo/promo.module.scss
+++ b/src/app/_components/promo/promo.module.scss
@@ -2,9 +2,16 @@
 
 .container {
   background-color: var(--mantine-color-black-3);
-  padding: 92px 32px;
+  padding: 92px 0px;
   @media (max-width: $mantine-breakpoint-sm) {
-    padding: 92px 16px;
+    padding: 92px 0px;
+  }
+  
+  .innerContainer {
+    padding: 0 32px;
+    @media (max-width: $mantine-breakpoint-sm) {
+      padding: 0 16px;
+    }
   }
 
   .text {

--- a/src/app/_components/promo/promo.module.scss
+++ b/src/app/_components/promo/promo.module.scss
@@ -6,7 +6,7 @@
   @media (max-width: $mantine-breakpoint-sm) {
     padding: 92px 0px;
   }
-  
+
   .innerContainer {
     padding: 0 32px;
     @media (max-width: $mantine-breakpoint-sm) {

--- a/src/app/_components/selectedDishes/SelectedDishes.module.scss
+++ b/src/app/_components/selectedDishes/SelectedDishes.module.scss
@@ -3,6 +3,10 @@
 .container {
   padding: 48px 32px 0;
 
+  @media (max-width: $mantine-breakpoint-sm) {
+    padding: 24px 16px 75px;
+  }
+
   h2 {
     grid-column: 1 / -1;
     justify-self: flex-start;
@@ -35,9 +39,5 @@
     display: flex;
     flex-direction: column;
     gap: 8px;
-  }
-
-  @media (max-width: $mantine-breakpoint-sm) {
-    padding: 24px 16px 75px;
   }
 }

--- a/src/app/_components/selectedDishes/SelectedDishes.module.scss
+++ b/src/app/_components/selectedDishes/SelectedDishes.module.scss
@@ -23,7 +23,7 @@
       grid-template-columns: repeat(2, minmax(0, 1fr));
     }
 
-    @media (max-width: $mantine-breakpoint-xs) {
+    @media (max-width:  $mantine-breakpoint-xs) {
       grid-template-columns: repeat(1, minmax(0, 1fr));
     }
   }

--- a/src/app/_components/selectedDishes/SelectedDishes.module.scss
+++ b/src/app/_components/selectedDishes/SelectedDishes.module.scss
@@ -10,28 +10,27 @@
   h2 {
     grid-column: 1 / -1;
     justify-self: flex-start;
-
   }
-  
+
   .grid {
     display: grid;
-    margin: 0 auto; 
-    grid-template-columns: repeat(4, minmax(0, 1fr)); 
-    gap: 32px 24px; 
-  
+    margin: 0 auto;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 32px 24px;
+
     @media (max-width: $mantine-breakpoint-lg) {
       grid-template-columns: repeat(3, minmax(0, 1fr));
     }
-  
+
     @media (max-width: $mantine-breakpoint-sm) {
       grid-template-columns: repeat(2, minmax(0, 1fr));
     }
 
-    @media (max-width:  $mantine-breakpoint-xs) {
+    @media (max-width: $mantine-breakpoint-xs) {
       grid-template-columns: repeat(1, minmax(0, 1fr));
     }
   }
-  
+
   .information {
     grid-column: 1 / -1;
     justify-self: flex-start;

--- a/src/app/_components/selectedDishes/SelectedDishes.module.scss
+++ b/src/app/_components/selectedDishes/SelectedDishes.module.scss
@@ -1,29 +1,33 @@
 @import '../../../styles/mantine';
 
 .container {
-  padding: 48px 0 0;
+  padding: 48px 32px 0;
 
   h2 {
     grid-column: 1 / -1;
     justify-self: flex-start;
-  }
 
+  }
+  
   .grid {
     display: grid;
-    margin: 0 40px;
-    grid-template-columns: repeat(3, 328px);
-    gap: 32px 24px;
-    justify-content: center;
-
+    margin: 0 auto; 
+    grid-template-columns: repeat(4, minmax(0, 1fr)); 
+    gap: 32px 24px; 
+  
     @media (max-width: $mantine-breakpoint-lg) {
-      grid-template-columns: repeat(2, 328px);
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+  
+    @media (max-width: $mantine-breakpoint-sm) {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
     }
 
-    @media (max-width: $mantine-breakpoint-sm) {
-      grid-template-columns: repeat(1, 328px);
+    @media (max-width: $mantine-breakpoint-xs) {
+      grid-template-columns: repeat(1, minmax(0, 1fr));
     }
   }
-
+  
   .information {
     grid-column: 1 / -1;
     justify-self: flex-start;
@@ -31,5 +35,9 @@
     display: flex;
     flex-direction: column;
     gap: 8px;
+  }
+
+  @media (max-width: $mantine-breakpoint-sm) {
+    padding: 24px 16px 75px;
   }
 }

--- a/src/app/_components/selectedDishes/SelectedDishes.tsx
+++ b/src/app/_components/selectedDishes/SelectedDishes.tsx
@@ -9,7 +9,11 @@ import scss from './SelectedDishes.module.scss';
 
 export default function SelectedDishes({ dishes }: { dishes: IDish[] }) {
   return (
-    <Container size={1120} className={scss.container}>
+    <Container
+      style={{ border: '2px solid red' }}
+      size={1120}
+      className={scss.container}
+    >
       <Box className={scss.grid}>
         <Title order={2}>Favoriter</Title>
         {dishes.map((dish, i) => (

--- a/src/app/_components/selectedDishes/SelectedDishes.tsx
+++ b/src/app/_components/selectedDishes/SelectedDishes.tsx
@@ -9,11 +9,7 @@ import scss from './SelectedDishes.module.scss';
 
 export default function SelectedDishes({ dishes }: { dishes: IDish[] }) {
   return (
-    <Container
-      style={{ border: '2px solid red' }}
-      size={1120}
-      className={scss.container}
-    >
+    <Container size={1120} className={scss.container}>
       <Box className={scss.grid}>
         <Title order={2}>Favoriter</Title>
         {dishes.map((dish, i) => (

--- a/src/app/_theme/theme.ts
+++ b/src/app/_theme/theme.ts
@@ -53,38 +53,38 @@ export const theme = createTheme({
       h1: {
         lineHeight: '1.3',
         fontWeight: '400',
-        fontSize: '69px',
+        fontSize: '61px',
       },
       h2: {
         lineHeight: '1.3',
         fontWeight: '400',
-        fontSize: '55px',
+        fontSize: '49px',
       },
       h3: {
         lineHeight: '1.3',
         fontWeight: '400',
-        fontSize: '44px',
+        fontSize: '39px',
       },
       h4: {
         lineHeight: '1.3',
         fontWeight: '400',
-        fontSize: '35px',
+        fontSize: '31px',
       },
       h5: {
         lineHeight: '1.3',
         fontWeight: '400',
-        fontSize: '28px',
+        fontSize: '25px',
       },
       h6: {
         lineHeight: '1.3',
         fontWeight: '400',
-        fontSize: '23px',
+        fontSize: '20px',
       },
     },
   },
   other: {
-    body1: '18px',
-    body2: '14px',
+    body1: '16px',
+    body2: '13px',
   },
   shadows: {
     primary: '0px 4px 4px 0px rgba(0, 0, 0, 0.25)',

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -29,7 +29,7 @@ body::-webkit-scrollbar {
 
 body,
 .mantine-Text-root {
-  font-size: 18px !important;
+  font-size: 16px !important;
   line-height: 1.5;
   color: var(--mantine-color-black-3);
 }


### PR DESCRIPTION
## Problem

Det fanns en upplevelse om att text om och vissa element på sidan var för stora.

## Lösning / Implementation

- All text är nu förminskad i temat.
- Korten  och bildelementen är nu förminskade. Detta rör främst startsidan och meny.

## Testning

![Screenshot 2024-01-23 at 17 22 50](https://github.com/Examensarbete-Sebbe-Ellen-o-Linus/DinePal/assets/115704961/e34a8b7b-bb11-452b-86e0-e0e8a4fc7edf)


![Screenshot 2024-01-23 at 17 22 59](https://github.com/Examensarbete-Sebbe-Ellen-o-Linus/DinePal/assets/115704961/aa2aa929-69de-4b3b-84f0-338610518a61)

![Screenshot 2024-01-23 at 17 23 14](https://github.com/Examensarbete-Sebbe-Ellen-o-Linus/DinePal/assets/115704961/0e05c44c-7e27-48e8-9de5-e6bb6ea4fa9e)

![Screenshot 2024-01-23 at 17 23 26](https://github.com/Examensarbete-Sebbe-Ellen-o-Linus/DinePal/assets/115704961/53c63483-d300-49d2-b52f-f34ce2372173)
